### PR TITLE
Fix GitHub Pages commit attribution

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,3 +85,5 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: build
           cname: help.toit.io
+          user_name: 'github-actions[bot]'
+          user_email: '41898282+github-actions[bot]@users.noreply.github.com'


### PR DESCRIPTION
## Summary

- configure the gh-pages deployment action to author commits as github-actions[bot]
- prevent generated deployment commits from appearing as personal contributions

## Verification

- git diff --check
- confirmed the configured email maps to the GitHub Actions bot account